### PR TITLE
fix: ensure index path exists before reading

### DIFF
--- a/lua/nvim-devdocs/list.lua
+++ b/lua/nvim-devdocs/list.lua
@@ -46,6 +46,7 @@ end
 
 M.get_updatable = function()
   if not registery_path:exists() then return {} end
+  if not index_path:exists() then return {} end
 
   local results = {}
   local registery_content = registery_path:read()


### PR DESCRIPTION
This changeset ensures the index.json exists before trying to read it.

When first fetching the `registry.json` would get created but not the `index.json` and an error would be thrown.

Instead of creating `index.json` we just check for it.