### PR TITLE
Implement after_open callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Here is the default configuration:
   picker_cmd = false, -- use cmd previewer in picker preview
   picker_cmd_args = {}, -- example using glow: { "-p" }
   ensure_installed = {}, -- get automatically installed
+  after_open = function(bufnr) end, -- callback that runs after the Devdocs window is opened. Devdocs buffer ID will be passed in
 }
 ```
 
@@ -95,6 +96,19 @@ Available commands:
 - `DevdocsUpdateAll`: Update all documentations.
 
 Commands support completion, and the Telescope picker will be used when no argument is provided.
+
+## Lifecycle Hook
+
+An `after_open` callback is supplied which accepts the buffer ID of the Devdocs window. It can be used for things like buffer-specific keymaps:
+
+```lua
+require('nvim-devdocs').setup({
+  -- ...
+  after_open = function(bufnr)
+    vim.api.nvim_buf_set_keymap(bufnr, 'n', '<Esc>', ':close<CR>', {})
+  end
+})
+```
 
 ## TODO
 

--- a/lua/nvim-devdocs/config.lua
+++ b/lua/nvim-devdocs/config.lua
@@ -16,6 +16,7 @@ local config = {
   picker_cmd = false,
   picker_cmd_args = {},
   ensure_installed = {},
+  after_open = function() end
 }
 
 M.get = function() return config end

--- a/lua/nvim-devdocs/operations.lua
+++ b/lua/nvim-devdocs/operations.lua
@@ -237,6 +237,8 @@ M.open = function(alias, bufnr, pattern, float)
   else
     vim.bo[bufnr].ft = "markdown"
   end
+
+  plugin_config.after_open(bufnr)
 end
 
 return M


### PR DESCRIPTION
I wanted to be able to set custom keymaps within the context of the Devdocs window, so I added an `after_open` callback function to expose the `bufnr`. Feedback is welcome and I'm happy to make any changes if you have an issue with my implementation. Thanks!