### PR TITLE
sections: only display after section start

### DIFF
--- a/lua/nvim-devdocs/config.lua
+++ b/lua/nvim-devdocs/config.lua
@@ -14,7 +14,6 @@ local config = {
   cmd_args = {},
   cmd_ignore = {},
   picker_cmd = false,
-  picker_cmd_args = {},
   ensure_installed = {},
   mappings = {
     open_in_browser = "",

--- a/lua/nvim-devdocs/config.lua
+++ b/lua/nvim-devdocs/config.lua
@@ -14,6 +14,7 @@ local config = {
   cmd_args = {},
   cmd_ignore = {},
   picker_cmd = false,
+  picker_cmd_args = {},
   ensure_installed = {},
   mappings = {
     open_in_browser = "",

--- a/lua/nvim-devdocs/operations.lua
+++ b/lua/nvim-devdocs/operations.lua
@@ -213,14 +213,15 @@ M.filter_doc = function(lines, pattern)
   return filtered_lines
 end
 
-M.render_cmd = function(bufnr)
+M.render_cmd = function(bufnr, is_picker)
   vim.bo[bufnr].ft = "glow"
 
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local chan = vim.api.nvim_open_term(bufnr, {})
+  local args = is_picker and plugin_config.picker_cmd_args or plugin_config.cmd_args
   local previewer = job:new({
     command = plugin_config.previewer_cmd,
-    args = plugin_config.cmd_args,
+    args = args,
     on_stdout = vim.schedule_wrap(function(_, data)
       if not data then return end
       local output_lines = vim.split(data, "\n", {})

--- a/lua/nvim-devdocs/operations.lua
+++ b/lua/nvim-devdocs/operations.lua
@@ -187,8 +187,31 @@ M.get_all_entries = function()
   return entries
 end
 
--- https://stackoverflow.com/a/34953646/516188
-local function create_pattern(text) return text:gsub("([^%w])", "%%%1") end
+M.filter_doc = function(lines, pattern)
+  if not pattern then return lines end
+
+  -- https://stackoverflow.com/a/34953646/516188
+  local function create_pattern(text) return text:gsub("([^%w])", "%%%1") end
+
+  local filtered_lines = {}
+  local found = false
+  local search_pattern = create_pattern(pattern)
+  local split = vim.split(pattern, " ")
+  local header = split[1]
+  local top_header = header and header:sub(1, #header - 1)
+
+  for _, line in ipairs(lines) do
+    if found and header then
+      local line_split = vim.split(line, " ")
+      local first = line_split[1]
+      if first and first == header or first == top_header then break end
+    end
+    if line:match(search_pattern) then found = true end
+    if found then table.insert(filtered_lines, line) end
+  end
+
+  return filtered_lines
+end
 
 M.open = function(entry, bufnr, pattern, float)
   vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
@@ -219,29 +242,6 @@ M.open = function(entry, bufnr, pattern, float)
     vim.bo[bufnr].ft = "glow"
 
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-    -- if we have a pattern to search for, only consider lines after the pattern
-    local filtered_lines = nil
-    local found = false
-
-    if pattern then
-      filtered_lines = {}
-
-      local search_pattern = create_pattern(pattern)
-      local split = vim.split(pattern, " ")
-      local header = split[1]
-      local top_header = header and header:sub(1, #header - 1)
-
-      for _, line in ipairs(lines) do
-        if found and header then
-          local line_split = vim.split(line, " ")
-          local first = line_split[1]
-          if first and first == header or first == top_header then break end
-        end
-        if line:match(search_pattern) then found = true end
-        if found then table.insert(filtered_lines, line) end
-      end
-    end
-
     local chan = vim.api.nvim_open_term(bufnr, {})
     local previewer = job:new({
       command = plugin_config.previewer_cmd,
@@ -252,7 +252,7 @@ M.open = function(entry, bufnr, pattern, float)
           vim.api.nvim_chan_send(chan, line .. "\r\n")
         end
       end),
-      writer = table.concat(filtered_lines or lines, "\n"),
+      writer = table.concat(lines, "\n"),
     })
     previewer:start()
   else

--- a/lua/nvim-devdocs/pickers.lua
+++ b/lua/nvim-devdocs/pickers.lua
@@ -63,7 +63,7 @@ local doc_previewer = previewers.new_buffer_previewer({
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, filtered_lines)
 
       if plugin_config.picker_cmd then
-        operations.render_cmd(bufnr)
+        operations.render_cmd(bufnr, true)
       else
         vim.bo[bufnr].ft = "markdown"
       end


### PR DESCRIPTION
fixes #28
It was wrong to give all the contents to the preview/display command and then search on the output, because the command could change the format completely.
So now we submit to the converter program only data after the section start, and we don't need to search the output anymore.