### PR TITLE
remove newlines in table cells

### DIFF
--- a/lua/nvim-devdocs/transpiler.lua
+++ b/lua/nvim-devdocs/transpiler.lua
@@ -340,7 +340,7 @@ function transpiler:eval_table(node)
 
       if not col_len then break end
 
-      result = result .. "| " .. value .. string.rep(" ", col_len - #value + 1)
+      result = result .. "| " .. string.gsub(value, "\n", "") .. string.gsub(string.rep(" ", col_len - #value + 1), "\n", "")
       current_col = current_col + 1
 
       if colspan > 1 then
@@ -375,7 +375,7 @@ function transpiler:eval_table(node)
             current_col = current_col + 1
           end
         end
-        result = result .. "| " .. line .. " "
+        result = result .. "| " .. string.gsub(line, "\n", "") .. " "
       end
 
       result = result .. "|\n"


### PR DESCRIPTION
prevents bad rendering such as
```
| cell1 | cell2
    |
```
will now be:
```
| cell1 | cell2 |
```

example of issue that fixes, `date_fns`, `addMinutes`.

before (glow rendered):
![image](https://github.com/luckasRanarison/nvim-devdocs/assets/339433/b5f27901-4392-4bd3-91c2-9c2b5a9c476b)

after:
![image](https://github.com/luckasRanarison/nvim-devdocs/assets/339433/ba8512f7-c6a5-494c-a064-1a25dae4b6b0)
