### PR TITLE
transpiler: special handling for inline images

### DIFF
--- a/lua/nvim-devdocs/transpiler.lua
+++ b/lua/nvim-devdocs/transpiler.lua
@@ -211,6 +211,8 @@ function transpiler:eval(node)
 
     if tag_name == "a" then
       result = string.format("[%s](%s)", result, attributes.href)
+    elseif tag_name == "img" and string.match(attributes.src, "^data:") then
+      result = string.format("![%s](%s)", attributes.alt, "data:inline_image")
     elseif tag_name == "img" then
       result = string.format("![%s](%s)", attributes.alt, attributes.src)
     elseif tag_name == "pre" and attributes["data-language"] then


### PR DESCRIPTION
we don't want to have potentially hundreds of kilobytes long base64 in the output. The javascript "Promise" documentation does this.

before (glow filtered, javascript Promise):
![image](https://github.com/luckasRanarison/nvim-devdocs/assets/339433/6462d8b9-f914-4329-b0d4-9884e85879b4)

after:
![image](https://github.com/luckasRanarison/nvim-devdocs/assets/339433/512de522-1c0f-4745-82b2-2d0408846bc4)
