### PR TITLE
Add state system

### DIFF
--- a/lua/nvim-devdocs/operations.lua
+++ b/lua/nvim-devdocs/operations.lua
@@ -3,6 +3,7 @@ local M = {}
 local job = require("plenary.job")
 local curl = require("plenary.curl")
 local path = require("plenary.path")
+local state = require("nvim-devdocs.state")
 
 local list = require("nvim-devdocs.list")
 local notify = require("nvim-devdocs.notify")
@@ -249,7 +250,16 @@ M.open = function(entry, bufnr, float)
     if not plugin_config.row then float_opts.row = row end
     if not plugin_config.col then float_opts.col = col end
 
-    local win = vim.api.nvim_open_win(bufnr, true, float_opts)
+    local win = nil
+    local last_win = state.get("last_win")
+
+    if last_win and vim.api.nvim_win_is_valid(last_win) then
+      win = last_win
+      vim.api.nvim_win_set_buf(win, bufnr)
+    else
+      win = vim.api.nvim_open_win(bufnr, true, float_opts)
+      state.set("last_win", win)
+    end
 
     vim.wo[win].wrap = plugin_config.wrap
     vim.wo[win].linebreak = plugin_config.wrap

--- a/lua/nvim-devdocs/pickers.lua
+++ b/lua/nvim-devdocs/pickers.lua
@@ -13,6 +13,7 @@ local list = require("nvim-devdocs.list")
 local notify = require("nvim-devdocs.notify")
 local operations = require("nvim-devdocs.operations")
 local transpiler = require("nvim-devdocs.transpiler")
+local plugin_state = require("nvim-devdocs.state")
 local plugin_config = require("nvim-devdocs.config").get()
 
 local new_docs_picker = function(prompt, entries, previwer, attach)
@@ -63,6 +64,7 @@ local doc_previewer = previewers.new_buffer_previewer({
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, filtered_lines)
 
       if plugin_config.previewer_cmd and plugin_config.picker_cmd then
+        plugin_state.set("preview_lines", filtered_lines)
         operations.render_cmd(bufnr, true)
       else
         vim.bo[bufnr].ft = "markdown"
@@ -72,17 +74,13 @@ local doc_previewer = previewers.new_buffer_previewer({
 })
 
 local open_doc = function(float)
-  local bufnr
+  local bufnr = nil
   local selection = action_state.get_selected_entry()
 
   if plugin_config.picker_cmd then
     bufnr = vim.api.nvim_create_buf(false, true)
-    local splited_path = vim.split(selection.value.path, ",")
-    local file = splited_path[1]
-    local file_path = path:new(plugin_config.dir_path, "docs", selection.value.alias, file .. ".md")
-    local lines = file_path:readlines()
-    local filtered_lines = operations.filter_doc(lines, splited_path[2])
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, filtered_lines)
+    local lines = plugin_state.get("preview_lines")
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   else
     bufnr = state.get_global_key("last_preview_bufnr")
   end

--- a/lua/nvim-devdocs/state.lua
+++ b/lua/nvim-devdocs/state.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+local state = {
+  preview_lines = nil,
+  last_win = nil,
+}
+
+M.get = function(key) return state[key] end
+
+M.set = function(key, value) state[key] = value end
+
+return M


### PR DESCRIPTION
Keep track of the current plugin state. This PR just fixes unnecessary read & win cloning, but state could be extended to add more features.