### PR TITLE
improved splitting: store end marker in registry

### DIFF
--- a/lua/nvim-devdocs/transpiler.lua
+++ b/lua/nvim-devdocs/transpiler.lua
@@ -121,6 +121,7 @@ function transpiler:new(source, section_map)
     result = "",
     section_map = section_map,
     sections = {},
+    section_list = {},
   }
   new.parser:parse()
   self.__index = self
@@ -248,7 +249,7 @@ function transpiler:transpile()
 
   self.result = self.result:gsub("\n\n\n+", "\n\n")
 
-  return self.result, self.sections
+  return self.result, self.sections, self.section_list
 end
 
 ---Returns the Markdown representation of a node
@@ -324,6 +325,7 @@ function transpiler:eval(node)
 
   if id and self.section_map and vim.tbl_contains(self.section_map, id) then
     self.sections[id] = vim.trim(result)
+    table.insert(self.section_list, id)
   end
 
   return result


### PR DESCRIPTION
fixes #54

this is what we were talking about... storing the next marker in the index so that we know where to cut the preview. works in my tests! fixes the case of rust, doesn't break any of the other docs I tested.